### PR TITLE
[eventic-autofix] ci: modernize GitHub Actions (checkout v3→v6, gh-release v2→v3)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Create Plugin Directory
@@ -22,7 +22,7 @@ jobs:
     - name: Zip Folder
       run: cd Build/ && zip -r AssetsBridge.zip .
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: Build/AssetsBridge.zip


### PR DESCRIPTION
## GitHub Actions modernization (auto-detected by Eventic)

CI is green — this PR is proactive drift remediation from the workflow scan run on the latest `check_suite.completed`. It bumps two outdated action references in `.github/workflows/master.yml` (the tag-triggered release workflow). **No workflow logic changes**, only `uses:` version pins.

### Changes
| Action | From | To | Tier |
|---|---|---|---|
| `actions/checkout` | `@v3` | `@v6` | first-party, low-risk |
| `softprops/action-gh-release` | `@v2` | `@v3` | third-party **major** |

### Why
- **`actions/checkout@v3 → @v6`** — v3 runs on the **Node 16** Actions runtime, which GitHub has deprecated; runners already emit "Node.js 16 actions are deprecated" warnings and will eventually hard-fail. v6 is the current major (Node 24). Behavior-identical for this usage (`fetch-depth: 0`).
- **`softprops/action-gh-release@v2 → @v3`** — per the upstream v3.0.0 notes, the **only** change is moving the action runtime from **Node 20 → Node 24**; inputs/outputs are unchanged. `ubuntu-latest` already provides the Node 24 runtime, so it is safe here. If you ever need the last Node 20 line, the upstream pin is `v2.6.2`.

### Why a PR (not a direct push)
`softprops/action-gh-release` is a **third-party major** bump, which policy routes to a PR for human review rather than a direct push — and it is the **release-critical** step of this workflow (it publishes `AssetsBridge.zip` to the GitHub Release). Since both edits live in the same file, the first-party `checkout` bump rides along in this same PR. Please confirm before merging.

> Note: merging this PR does **not** cut a tag or trigger a release — the workflow only fires on `push:` of a `v*.*.*` tag, which remains your action alone.

— Eventic autofix (delivery `b60069b0-5bb3-11f1-8f30-eb94073625dd`, upstream `12a00c4e`)
